### PR TITLE
Fix panic in GpuInfo

### DIFF
--- a/bench/gpu.go
+++ b/bench/gpu.go
@@ -10,8 +10,11 @@ func GpuInfo() (gpu string) {
 	if err != nil {
 		return
 	}
-	if len(info.GraphicsCards) == 0 {
-		return
+
+	for _, gc := range info.GraphicsCards {
+		if gc.DeviceInfo != nil {
+			return gc.DeviceInfo.Product.Name
+		}
 	}
-	return info.GraphicsCards[0].DeviceInfo.Product.Name
+	return
 }


### PR DESCRIPTION
On my PC it finds 5 graphic cards and some of them contain "nil" DeviceInfo.
That's why we need find first graphics card which doesn't have a "nil" DeviceInfo to correctly determine the GPU name.